### PR TITLE
Handle "boolean" options as tri-state inputs

### DIFF
--- a/pip_inside/__init__.py
+++ b/pip_inside/__init__.py
@@ -64,13 +64,19 @@ def install(*args, **kwargs):
     else:
         cli_args = ['pip', 'install']
         for k, v in kwargs.items():
-            if len(k) == 1:  # short flag
-                cli_args.append("-" + k)
-                if isinstance(v, six.string_types):  # Non-string = boolean
-                    cli_args.append(v)
-            else:  # long flag
-                cli_args.append("--" + k.replace('_', '-'))
-                if isinstance(v, six.string_types):  # Non-string = boolean
+            # When the arg value is a string, both it and the option are appended to the CLI args
+            # Otherwise we assume the value indicates whether or not to include a boolean flag
+            append_value = isinstance(v, six.string_types)
+            if append_value and not v:
+                raise ValueError("Empty string passed as value for option {}".format(k))
+            append_option = append_value or v
+            if append_option:
+                if len(k) == 1:  # short flag
+                    option = "-" + k
+                else:  # long flag
+                    option = "--" + k.replace('_', '-')
+                cli_args.append(option)
+                if append_value:
                     cli_args.append(v)
         cli_args += args
     # use pip internals to isolate package names

--- a/pip_inside/__init__.py
+++ b/pip_inside/__init__.py
@@ -65,27 +65,29 @@ def install(*args, **kwargs):
         cli_args = ['pip', 'install']
         # Keyword arguments are translated to CLI options
         for raw_k, v in kwargs.items():
-            k = raw_k.replace('_', '-') # Translate Python identifiers to CLI long option names
+            k = raw_k.replace('_', '-')  # Python identifiers -> CLI long names
             append_value = isinstance(v, six.string_types)
-            if append_value
-                # When the arg value is a string, both it and the option are appended to the CLI args
-                append_option=True
+            if append_value:
+                # When arg value is str, append both it and option to CLI args
+                append_option = True
                 if not v:
-                    raise ValueError("Empty string passed as value for option {}".format(k))
+                    raise ValueError("Empty string passed as value for option "
+                                     "{}".format(k))
             else:
-                # Otherwise we assume the value indicates whether or not to include a boolean flag and
-                # handle it as a tri-state setting (None->omit, true->include, false->include negated)
+                # assume the value indicates whether to include a boolean flag.
+                # None->omit, true->include, false->include negated
                 append_option = v is not None
                 if k.startswith("no-"):
-                    # Instead of accepting both `some-option=True` and `no-some-option=False`, we
-                    # disallow the second spelling, but suggest the former when the latter is tried
+                    # suggest `some-option=True` instead of
+                    # `no-some-option=False`
                     raw_suffix = raw_k[3:]
-                    msg_template = "Rather than '{}={!r}', try '{{}}={{!r}}'".format(raw_k, v)
+                    msg_template = ("Rather than '{}={!r}', "
+                                    "try '{{}}={{!r}}'".format(raw_k, v))
                     if append_option:
-                        translation_suggestion = msg_template.format(raw_suffix, not v)
+                        suggestion = msg_template.format(raw_suffix, not v)
                     else:
-                        translation_suggestion = msg_template.format(raw_suffix, None)
-                    raise ValueError(translation_suggestion)                   
+                        suggestion = msg_template.format(raw_suffix, None)
+                    raise ValueError(suggestion)
                 if append_option and not v:
                     k = "no-" + k
             if append_option:


### PR DESCRIPTION
Refactor and amend the boolean option handling so that:

* passing `None` keeps the option from being added
  to the CLI argument list
* any true value adds it with a `--` prefix (or `-` for single-letter options)
* any false value adds it with a `--no-` prefix

`pip` will error out on some combinations that this permits, but the
place to resolve that is to make the `pip` CLI more consistent
(and perhaps eventually add special case handling for some
keyword options).